### PR TITLE
Update Travis build to Kernel 4.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.14-rc1
+            - libelf-dev
+      env: COMPILER=gcc-5 KVER=4.15
     - compiler: gcc
       addons:
         apt:
@@ -33,7 +34,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
-      env: COMPILER=gcc-6 KVER=4.14-rc1
+            - libelf-dev
+      env: COMPILER=gcc-6 KVER=4.15
     - compiler: gcc
       addons:
         apt:
@@ -41,7 +43,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-7
-      env: COMPILER=gcc-7 KVER=4.14-rc1
+            - libelf-dev
+      env: COMPILER=gcc-7 KVER=4.15
     - compiler: gcc
       addons:
         apt:
@@ -49,7 +52,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
-      env: COMPILER=gcc-6 KVER=4.9.51
+      env: COMPILER=gcc-6 KVER=4.14.16
     - compiler: gcc
       addons:
         apt:


### PR DESCRIPTION
- Update Travis build to Kernel 4.15
- Removed 4.9.51 and used last LTS (4.14.16)

It's a fast change done with Github editor, untested.